### PR TITLE
fix(auth): Parse URL from request parts to enable `wasmtime serve`

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -7,5 +7,5 @@ fn handle_http_handler(_req: Request) -> anyhow::Result<impl IntoResponse> {
     Ok(http::Response::builder()
         .status(200)
         .header("content-type", "text/plain")
-        .body("Hello, Fermyon!")?)
+        .body("Business logic executed!")?)
 }

--- a/github-oauth/src/api/authorize.rs
+++ b/github-oauth/src/api/authorize.rs
@@ -1,10 +1,10 @@
 use super::OAuth2;
 use oauth2::{CsrfToken, RedirectUrl, Scope};
-use spin_sdk::http::{Headers, IncomingRequest, OutgoingResponse, ResponseOutparam};
+use spin_sdk::http::{Headers, OutgoingResponse, ResponseOutparam};
 
 /// `authorize` kicks off the oauth flow constructing the authorization url and redirecting the client to github
 /// to authorize the application to the user's profile.
-pub async fn authorize(_request: IncomingRequest, output: ResponseOutparam) {
+pub async fn authorize(output: ResponseOutparam) {
     let client = match OAuth2::try_init() {
         Ok(config) => {
             let redirect_url = RedirectUrl::new("http://127.0.0.1:3000/login/callback".to_string())

--- a/github-oauth/src/api/callback.rs
+++ b/github-oauth/src/api/callback.rs
@@ -1,12 +1,10 @@
 use super::OAuth2;
 use cookie::{Cookie, SameSite};
 use oauth2::{AuthorizationCode, CsrfToken, RedirectUrl, TokenResponse};
-use spin_sdk::http::{
-    send, Headers, IncomingRequest, OutgoingResponse, ResponseOutparam, SendError,
-};
+use spin_sdk::http::{send, Headers, OutgoingResponse, ResponseOutparam, SendError};
 use url::Url;
 
-pub async fn callback(url: Url, _request: IncomingRequest, output: ResponseOutparam) {
+pub async fn callback(url: Url, output: ResponseOutparam) {
     let client = match OAuth2::try_init() {
         Ok(config) => {
             let redirect_url = RedirectUrl::new("http://127.0.0.1:3000/login/callback".to_string())
@@ -85,13 +83,13 @@ fn get_code_and_state_param(url: &Url) -> anyhow::Result<(AuthorizationCode, Csr
     const STATE_QUERY_PARAM_NAME: &str = "state";
     const CODE_QUERY_PARAM_NAME: &str = "code";
 
-    let Some(param) = get_query_param(&url, STATE_QUERY_PARAM_NAME) else {
+    let Some(param) = get_query_param(url, STATE_QUERY_PARAM_NAME) else {
         anyhow::bail!("missing '{STATE_QUERY_PARAM_NAME}' query parameter");
     };
 
     let state = CsrfToken::new(param);
 
-    let Some(param) = get_query_param(&url, CODE_QUERY_PARAM_NAME) else {
+    let Some(param) = get_query_param(url, CODE_QUERY_PARAM_NAME) else {
         anyhow::bail!("missing '{CODE_QUERY_PARAM_NAME}' query parameter");
     };
 

--- a/github-oauth/src/api/login.rs
+++ b/github-oauth/src/api/login.rs
@@ -1,7 +1,7 @@
-use spin_sdk::http::{Headers, IncomingRequest, OutgoingResponse, ResponseOutparam};
+use spin_sdk::http::{Headers, OutgoingResponse, ResponseOutparam};
 
 /// `login` returns the login page.
-pub async fn login(_request: IncomingRequest, output: ResponseOutparam) {
+pub async fn login(output: ResponseOutparam) {
     const LOGIN_HTML: &[u8] = include_bytes!("../../login.html"); // TODO: this shouldn't be included statically.
 
     let headers = Headers::new(&[("content-type".to_string(), b"text/html".to_vec())]);


### PR DESCRIPTION
Spin's HTTP crate formats a uri of a request, while `wasmtime` does not, leaving it as solely being the path (`/`).

This constructs the url from the request parts rather than relying on the spin crate, making it a more universal component that can now run with wasmtime with `wasmtime serve service.wasm --addr 127.0.0.1:3000`

Also, removes unused arguments